### PR TITLE
modify Register new beneficiary behavior

### DIFF
--- a/vision-aid-prototype-v1/pages/api/beneficiary.js
+++ b/vision-aid-prototype-v1/pages/api/beneficiary.js
@@ -85,7 +85,7 @@ async function readData(req, res) {
           Training: true,
         },
       });
-    } else if (req.query.beneficiaryName != null) {
+    } else if (req.query.beneficiaryName != '') {
       beneficiary = await prisma.beneficiary.findMany({
         where: {
           beneficiaryName: {
@@ -106,22 +106,7 @@ async function readData(req, res) {
         },
       });
     } else {
-      beneficiary = await prisma.beneficiary.findMany({
-        include: {
-          hospital: true,
-          Computer_Training: true,
-          Mobile_Training: true,
-          Orientation_Mobility_Training: true,
-          Vision_Enhancement: true,
-          Comprehensive_Low_Vision_Evaluation: true,
-          Counselling_Education: true,
-          Low_Vision_Evaluation: true,
-          Training: true,
-        },
-        where: {
-          deleted: false,
-        },
-      });
+      beneficiary = [];
     }
     return res.status(200).json(beneficiary, { success: true });
   } catch (error) {


### PR DESCRIPTION
- if a blank search query is provided:
  - Register goes to the form without showing "Continue" button
- Search returns a message telling the users that no beneficiaries exist

- if the search query doesn't exist:
  - Register goes to the form with the name filled with the search query
  - Search returns the same message as above

- if the search query exists partially:
  - Register shows the list of beneficiaries and asks user to "Continue"
  - Search returns the list of beneficiaries